### PR TITLE
Построить по стенам на основе линии: Добавлена проверка на BoundingBox

### DIFF
--- a/2D.tab/Оформление.panel/Оформление 1.stack/Размеры.pulldown/Построить по стенам на основе линии.pushbutton/script.py
+++ b/2D.tab/Оформление.panel/Оформление 1.stack/Размеры.pulldown/Построить по стенам на основе линии.pushbutton/script.py
@@ -34,6 +34,7 @@ filter_categories = List[BuiltInCategory]([BuiltInCategory.OST_Walls,
 elements = FilteredElementCollector(doc, view.Id) \
     .WherePasses(ElementMulticategoryFilter(filter_categories)) \
     .ToElements()
+elements = filter(lambda e: e.BoundingBox[view] is not None, elements)
 
 class Utils:
     def __init__(self):


### PR DESCRIPTION
# Обновления

- Добавлена фильтрация элементов, у которых нет BoundingBox, из-за которых плагин выдает ошибку при попытке получить точки этого бокса в `CashedElement`